### PR TITLE
Add option to generate a mapping JSON manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,21 @@ Required: `true`
 
 Hashing algorithm used to generate hash. Can be one of `md5`, `sha1`, `sha256`, `sha512`
 
+### manifest
+
+Type: `string`
+Required: `false`
+
+Filename to write a manifest to. Will generate a JSON manifest mapping input file to hashed output. 
+Useful if you want to dynamically generate link to your hashed output server-side.
+
+Example manifest:
+```json
+{
+	"main.js": "main.56770a64be1a1132502b276c4132a76bb94d9e1b.js"
+}
+```
+
 # License
 
 MIT ©

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Hashing algorithm used to generate hash. Can be one of `md5`, `sha1`, `sha256`, 
 Type: `string`
 Required: `false`
 
-Filename to write a manifest to. Will generate a JSON manifest mapping input file to hashed output. 
+Filename to write a manifest to. Will generate a JSON manifest mapping input filename to hashed output filename. 
 Useful if you want to dynamically generate link to your hashed output server-side.
 
 Example manifest:

--- a/src/index.js
+++ b/src/index.js
@@ -16,11 +16,20 @@ const defaultOptions = {
 
 const msg = {
 	noTemplate: '[Hash] Destination filename must contain `[hash]` template.',
-	noAlgorithm: '[Hash] Algorithm can only be one of: md5, sha1, sha256, sha512'
+	noAlgorithm: '[Hash] Algorithm can only be one of: md5, sha1, sha256, sha512',
+	noManifest: '[Hash] Manifest filename must be a string'
 };
 
 function hasTemplate(dest) {
 	return /\[hash\]/.test(dest);
+}
+
+function generateManifest(input, output) {
+	return `
+		{
+			"${input}": "${output}"
+		}
+	`;
 }
 
 function formatFilename(dest, hash) {
@@ -58,11 +67,22 @@ export default function hash(opts = {}) {
 				return false;
 			}
 
+			if(options.manifest && typeof options.manifest !== 'string') {
+				logError(msg.noManifest);
+				return false;
+			}
+
 			const hash = hasha(data.code, options);
 			const fileName = formatFilename(options.dest, hash);
 
 			if(options.replace) {
 				fs.unlinkSync(bundle.dest);
+			}
+
+			if(options.manifest) {
+				const manifest = generateManifest(bundle.dest, fileName);
+				mkdirpath(options.manifest);
+				fs.writeFileSync(options.manifest, manifest, 'utf8');
 			}
 
 			mkdirpath(fileName);

--- a/test/index.js
+++ b/test/index.js
@@ -11,7 +11,8 @@ process.chdir('test');
 
 const results = {
 	'md5': '07d2bf0d12655d9f51c0637718da4889.js',
-	'sha1': '56770a64be1a1132502b276c4132a76bb94d9e1b.js'
+	'sha1': '56770a64be1a1132502b276c4132a76bb94d9e1b.js',
+	'manifest': 'manifest.json'
 };
 
 function hashWithOptions(options) {
@@ -102,6 +103,18 @@ describe('rollup-plugin-hash', () => {
 			const hash = results.sha1.replace('.js', '');
 			const isDirectory = fs.lstatSync('tmp/' + hash).isDirectory();
 			expect(isDirectory).to.be.true;
+		});
+	});
+
+	it('should create a manifest.json if configured', () => {
+		const res = hashWithOptions({ dest: 'tmp/[hash].js', manifest: 'tmp/manifest.json' });
+		return res.then(() => {
+			const tmp = fs.readdirSync('tmp');
+			const manifest = require('./tmp/manifest.json');
+			expect(tmp).to.contain(results.manifest);
+			expect(manifest).to.be.an('object');
+			expect(manifest).to.have.property('tmp/index.js');
+			expect(manifest['tmp/index.js']).to.equal('tmp/' + results.sha1);
 		});
 	});
 


### PR DESCRIPTION
Add an option to output a manifest JSON to map input file to hashed output destination. Useful to dynamically generate link to hashed bundle server-side.