### PR TITLE
Replace template literal with JSON.stringify

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,11 +26,7 @@ function hasTemplate(dest) {
 }
 
 function generateManifest(input, output) {
-	return `
-		{
-			"${input}": "${output}"
-		}
-	`;
+	return JSON.stringify({[input]: output});
 }
 
 function formatFilename(dest, hash) {
@@ -96,4 +92,3 @@ export default function hash(opts = {}) {
 		}
 	};
 }
-


### PR DESCRIPTION
Constructing the manifest JSON file in this way causes issues in certain environments (I ran into this loading the manifest as a data file in jekyll) due to the generated tab characters being included. Using the native `JSON.stringify()` here is a safer option in my opinion.