### PR TITLE
Support newer (0.48.x) rollup interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "chai-as-promised": "^6.0.0",
     "eslint": "^3.13.1",
     "mocha": "^3.2.0",
-    "rollup": "^0.41.4",
+    "rollup": "^0.48.0",
     "rollup-plugin-buble": "^0.15.0",
     "rollup-plugin-commonjs": "^7.0.0",
     "rollup-plugin-node-resolve": "^2.0.0"

--- a/src/index.js
+++ b/src/index.js
@@ -53,8 +53,10 @@ export default function hash(opts = {}) {
 	return {
 		name: 'hash',
 		onwrite: function(bundle, data) {
+			const destinationOption = options.output ? options.output.file : options.dest;
+			const builtFile = bundle.file || bundle.dest;
 
-			if(!options.dest || !hasTemplate(options.dest)) {
+			if(!destinationOption || !hasTemplate(destinationOption)) {
 				logError(msg.noTemplate);
 				return false;
 			}
@@ -75,14 +77,14 @@ export default function hash(opts = {}) {
 			}
 
 			const hash = hasha(data.code, options);
-			const fileName = formatFilename(options.dest, hash);
+			const fileName = formatFilename(destinationOption, hash);
 
 			if(options.replace) {
-				fs.unlinkSync(bundle.dest);
+				fs.unlinkSync(builtFile);
 			}
 
 			if(options.manifest) {
-				const manifest = generateManifest(options.manifestKey || bundle.dest, fileName);
+				const manifest = generateManifest(options.manifestKey || builtFile, fileName);
 				mkdirpath(options.manifest);
 				fs.writeFileSync(options.manifest, manifest, 'utf8');
 			}


### PR DESCRIPTION
**Rationale**: This plugin does not actually work with `rollup` version 0.48.x and the `manifest` or `replace` options because rollup changed their API.

**Solution**: Adapt the plugin to support current rollup versions in a backwards compatible way

**Closes**: #9