### PR TITLE
use existing manifest file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,8 +25,13 @@ function hasTemplate(dest) {
 	return /\[hash\]/.test(dest);
 }
 
-function generateManifest(input, output) {
-	return JSON.stringify({[input]: output});
+function tryRequire(file) {
+	try {
+		return JSON.parse(fs.readFileSync(file, 'utf-8'));
+	} catch (err) {
+		if (err.code === 'ENOENT') return null;
+		throw err;
+	}
 }
 
 function formatFilename(dest, hash) {
@@ -84,9 +89,10 @@ export default function hash(opts = {}) {
 			}
 
 			if(options.manifest) {
-				const manifest = generateManifest(options.manifestKey || builtFile, fileName);
+				const manifest = tryRequire(options.manifest) || {};
+				manifest[options.manifestKey || builtFile] = fileName;
 				mkdirpath(options.manifest);
-				fs.writeFileSync(options.manifest, manifest, 'utf8');
+				fs.writeFileSync(options.manifest, JSON.stringify(manifest), 'utf8');
 			}
 
 			mkdirpath(fileName);


### PR DESCRIPTION
Here's the promised PR for #6. I didn't introduce a new option for it because I can't imagine there are occasions when you *wouldn't* want this behaviour, but let me know if you disagree and I'll update the PR.

It uses `JSON.parse(fs.readFileSync(...))` rather than `require(...)` — both in the source and the tests — because `require` causes stuff to get cached, which wreaks havoc in the tests when you require `tmp/manifest.json` more than once, as we are now.