### PR TITLE
implement sourcemap support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,24 @@ export default function hash(opts = {}) {
 			}
 
 			mkdirpath(fileName);
-			fs.writeFileSync(fileName, data.code, 'utf8');
+
+			let code = data.code;
+			if (bundle.sourcemap) {
+				const basename = path.basename(fileName);
+				data.map.file = basename;
+
+				let url;
+				if (bundle.sourcemap === 'inline') {
+					url = data.map.toUrl();
+				} else {
+					url = basename + '.map';
+					fs.writeFileSync(fileName + '.map', data.map.toString());
+				}
+
+				code += `\n//# sourceMappingURL=${url}`;
+			}
+
+			fs.writeFileSync(fileName, code, 'utf8');
 		}
 	};
 }


### PR DESCRIPTION
fixes #5. Supports both external and inline sourcemaps, and rewrites the `file` property of the sourcemap to point to the hashed file