### PR TITLE
add feature to truncate hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ rollup({
 });
 ```
 
+Meanwhile, if dest filename is written the following way, only first 4 characters of hash will
+be used in final filename: `main.[hash:4].js`. You could change this number to modify the
+output result.
 
 ## Options
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,8 +21,10 @@ const msg = {
 	noManifestKey: '[Hash] Key for manifest filename must be a string'
 };
 
+const pattern = /\[hash(?::(\d+))?\]/;
+
 function hasTemplate(dest) {
-	return /\[hash\]/.test(dest);
+	return pattern.test(dest);
 }
 
 function generateManifest(input, output) {
@@ -30,7 +32,13 @@ function generateManifest(input, output) {
 }
 
 function formatFilename(dest, hash) {
-	return dest.replace('[hash]', hash);
+	const match = pattern.exec(dest);
+	const length = match && match[1];
+	let hashResult = hash;
+	if (length) {
+		hashResult = hash.substr(0, +length);
+	}
+	return dest.replace(pattern, hashResult);
 }
 
 function mkdirpath (dest) {

--- a/test/index.js
+++ b/test/index.js
@@ -90,6 +90,22 @@ describe('rollup-plugin-hash', () => {
 		});
 	});
 
+	it('should replace dest filename template with sub-string of bundle hash', () => {
+		const res = hashWithOptions({ dest: 'tmp/[hash:4].js' });
+		return res.then(() => {
+			const tmp = fs.readdirSync('tmp');
+			expect(tmp).to.contain(`${results.sha1.substr(0, 4)}.js`);
+		});
+	});
+
+	it('should use bundle hash when substring length is greater then original', () => {
+		const res = hashWithOptions({ dest: 'tmp/[hash:41].js' });
+		return res.then(() => {
+			const tmp = fs.readdirSync('tmp');
+			expect(tmp).to.contain(results.sha1);
+		});
+	});
+
 	it(`should create dest folder structure if doesn't exist`, () => {
 		const res = hashWithOptions({ dest: 'tmp/test/[hash].js' });
 		return res.then(() => {


### PR DESCRIPTION
Hi, I would like to propose this similar feature as in Webpack, where you can use `[hash:4]` to only include the first 4 chars of hash