### PR TITLE
Add a callback option to receive the hashed filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ Required: `false`
 The filename used as the input key in the generated manifest map. 
 Useful in certain build setups where `path.resolve` is needed as `bundle.dest` but not in the manifest.
 
+### callback
+
+Type: `function`
+Required: `false`
+
+Callback which is called with the resulting hashed filename. This is useful if you are integrating with other build steps and want to store the filename locally to be used in subsequent configs etc.
+
 # License
 
 MIT ©

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "buble": "^0.15.2",
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
+    "chai-spies": "^0.7.1",
     "eslint": "^3.13.1",
     "mocha": "^3.2.0",
     "rollup": "^0.48.0",

--- a/src/index.js
+++ b/src/index.js
@@ -116,6 +116,10 @@ export default function hash(opts = {}) {
 			}
 
 			fs.writeFileSync(fileName, code, 'utf8');
+
+			if(options.callback && typeof options.callback === 'function') {
+				options.callback(fileName);
+			}
 		}
 	};
 }

--- a/test/index.js
+++ b/test/index.js
@@ -5,7 +5,9 @@ const { rollup } = require('rollup');
 const chai = require('chai');
 const expect = chai.expect;
 const chaiAsPromised = require('chai-as-promised');
+const chaiSpies = require('chai-spies');
 
+chai.use(chaiSpies);
 chai.use(chaiAsPromised);
 process.chdir('test');
 
@@ -178,4 +180,12 @@ describe('rollup-plugin-hash', () => {
 		});
 	});
 
+	it('should call a callback with the hashed filename, if supplied', () => {
+		const callback = chai.spy();
+		const res = hashWithOptions({ dest: 'tmp/[hash].js', manifest: 'tmp/manifest.json', callback });
+		return res.then(() => {
+			expect(callback).to.have.been.called.once;
+			expect(callback).to.have.been.called.with(`tmp/${results.sha1}`);
+		});
+	});
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -134,6 +134,10 @@ chai-as-promised@^6.0.0:
   dependencies:
     check-error "^1.0.2"
 
+chai-spies@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/chai-spies/-/chai-spies-0.7.1.tgz#343d99f51244212e8b17e64b93996ff7b2c2a9b1"
+
 chai@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-3.5.0.tgz#4d02637b067fe958bdbfdd3a40ec56fef7373247"


### PR DESCRIPTION
Fixes #14. 

Often users have a situation where they have they array of sequential builds in a single config — one for the client, one for the service worker, one for the server etc — and each config depends on the output of the previous one. 

This introduces a `callback` option which is called with the hashed filename, so it can be stored locally and used in subsequent configs.