### PR TITLE
Replace original sourcemap when replace is true

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -108,6 +108,9 @@ export default function hash(opts = {}) {
 				if (bundle.sourcemap === 'inline') {
 					url = data.map.toUrl();
 				} else {
+					if (options.replace) {
+						fs.unlinkSync(builtFile + '.map');
+					}
 					url = basename + '.map';
 					fs.writeFileSync(fileName + '.map', data.map.toString());
 				}

--- a/test/index.js
+++ b/test/index.js
@@ -123,6 +123,14 @@ describe('rollup-plugin-hash', () => {
 		});
 	});
 
+	it('should replace original bundle and sourcemap with hashed version if configured', () => {
+		const res = hashWithOptions({ dest: 'tmp/[hash].js', replace: true }, { sourcemap: true });
+		return res.then(() => {
+			const tmp = fs.readdirSync('tmp');
+			expect(tmp).to.have.length(2);
+		});
+	});
+
 	it('should replace dest filename template with sub-string of bundle hash', () => {
 		const res = hashWithOptions({ dest: 'tmp/[hash:4].js' });
 		return res.then(() => {


### PR DESCRIPTION
When `replace` and `sourcemap` are both true, the plugin should also
remove the original sourcemap file, as already done for the main output
file.