### PR TITLE
Add bundle name placeholder - resolve merge conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "pretest": "npm run build",
     "test": "mocha",
     "build": "rollup -c",
-    "prepublish": "npm run lint && npm test && npm run build"
+    "prepare": "npm run lint && npm test && npm run build"
   },
   "devDependencies": {
     "buble": "^0.15.2",

--- a/src/index.js
+++ b/src/index.js
@@ -33,8 +33,9 @@ function generateManifest(input, output) {
 	`;
 }
 
-function formatFilename(dest, hash) {
-	return dest.replace('[hash]', hash);
+function formatFilename(dest, hash, name) {
+	return dest.replace('[hash]', hash)
+		.replace('[name]', name);
 }
 
 function mkdirpath (dest) {
@@ -79,7 +80,7 @@ export default function hash(opts = {}) {
 			}
 
 			const hash = hasha(data.code, options);
-			const fileName = formatFilename(options.dest, hash);
+			const fileName = formatFilename(options.dest, hash, path.parse(bundle.dest).name);
 
 			if(options.replace) {
 				fs.unlinkSync(bundle.dest);

--- a/src/index.js
+++ b/src/index.js
@@ -87,7 +87,7 @@ export default function hash(opts = {}) {
 			}
 
 			const hash = hasha(data.code, options);
-			const fileName = formatFilename(destinationOption, hash, path.parse(bundle.dest).name);
+			const fileName = formatFilename(destinationOption, hash, path.parse(builtFile).name);
 
 			if(options.replace) {
 				fs.unlinkSync(builtFile);

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -7,6 +7,7 @@
 		"beforeEach": true,
 		"afterEach": true,
 		"before": true,
-		"after": true
+		"after": true,
+		"Buffer": true
 	}
 }

--- a/test/index.js
+++ b/test/index.js
@@ -73,6 +73,14 @@ describe('rollup-plugin-hash', () => {
 		});
 	});
 
+	it('should replace dynamic dest filename template with hash and filename of bundle', () => {
+		const res = hashWithOptions({ dest: 'tmp/[name]-[hash].js' });
+		return res.then(() => {
+			const tmp = fs.readdirSync('tmp');
+			expect(tmp).to.contain(`index-${results.sha1}`);
+		});
+	});
+
 	it('should support alternative hashing algorithms if configured', () => {
 		const res = hashWithOptions({ dest: 'tmp/[hash].js', algorithm: 'md5' });
 		return res.then(() => {


### PR DESCRIPTION
This allows for `[name]` to be used in the template. Fixes merge conflicts in the PR from last year and makes some needed updates

Should be a non-breaking change and is covered by tests